### PR TITLE
fix(build): emit typescript declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "esbuild ./src --bundle --platform=node --outfile=build/index.js",
+    "build": "npm run build:clean && npm run build:esbuild && npm run build:declarations",
+    "build:clean": "rimraf build",
+    "build:esbuild": "esbuild ./src --bundle --platform=node --outfile=build/index.js",
+    "build:declarations": "tsc -p tsconfig.dist.json --emitDeclarationOnly --outFile build/index.d.ts",
     "prettier-check": "prettier -c ./src",
     "prepare": "yarn prettier-check && npm run test && npm run build"
   },
@@ -28,7 +31,9 @@
     "husky": "^7.0.0",
     "jest": "^27.1.1",
     "prettier": "^2.4.0",
-    "pretty-quick": "^3.1.1"
+    "pretty-quick": "^3.1.1",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.4.4"
   },
   "keywords": [
     "pdf",

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,7 +3014,7 @@ resolve@^1.14.2, resolve@^1.20.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3263,6 +3263,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
As esbuild doesn't and cannot emit typescript declaration files, this PR adds `tsc --emitDeclarationOnly` to generate the proper `index.d.ts` file. As suggested at: https://github.com/evanw/esbuild/issues/95#issuecomment-781863107

Resolves #1 