### PR TITLE
fix: fix getting printers and default printer on non-english systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ getDefaultPrinter().then(console.log);
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE) for details.
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) for details.

--- a/src/get-default-printer/get-default-printer.ts
+++ b/src/get-default-printer/get-default-printer.ts
@@ -4,7 +4,9 @@ import parsePrinterDescription from "../utils/parse-printer-description";
 
 export default async function getDefaultPrinter(): Promise<Printer | null> {
   try {
-    const { stdout } = await execAsync("lpstat -d");
+    const { stdout } = await execAsync("lpstat -d", {
+      env: { LC_ALL: "en_US" },
+    });
     const printer = getPrinterName(stdout);
     if (!printer) return null;
     return {
@@ -22,6 +24,8 @@ function getPrinterName(output: string): string {
 }
 
 async function getPrinterDescription(printer: string): Promise<string> {
-  const { stdout } = await execAsync(`lpstat -lp ${printer}`);
+  const { stdout } = await execAsync(`lpstat -lp ${printer}`, {
+    env: { LC_ALL: "en_US" },
+  });
   return parsePrinterDescription(stdout);
 }

--- a/src/get-printers/get-printers.ts
+++ b/src/get-printers/get-printers.ts
@@ -4,7 +4,9 @@ import parsePrinterDescription from "../utils/parse-printer-description";
 
 export default async function getPrinters(): Promise<Printer[]> {
   try {
-    const { stdout } = await execAsync("lpstat -lp");
+    const { stdout } = await execAsync("lpstat -lp", {
+      env: { LC_ALL: "en_US" },
+    });
 
     const isThereAnyPrinter = stdout.match("printer");
     if (!isThereAnyPrinter) return [];

--- a/src/print/print.ts
+++ b/src/print/print.ts
@@ -21,5 +21,7 @@ export default async function print(
     options.forEach((arg) => args.push(arg));
   }
 
-  return execAsync(`lp ${args.join(" ")}`);
+  return execAsync(`lp ${args.join(" ")}`, {
+    env: { LC_ALL: "en_US" },
+  });
 }


### PR DESCRIPTION
On non-english systems, the printer lines start with the localized word for "printer", which breaks parsing. As a fix, this PR enforces an english locale.