### PR TITLE
feat: additional printer attributes

### DIFF
--- a/src/get-default-printer/get-default-printer.spec.ts
+++ b/src/get-default-printer/get-default-printer.spec.ts
@@ -35,6 +35,9 @@ it("returns the system default printer", async () => {
   const expected: Printer = {
     printer: "Virtual_PDF_Printer",
     description: "Virtual PDF Printer",
+    status: "idle",
+    connection: "direct",
+    alerts: "none",
   };
 
   await expect(getDefaultPrinter()).resolves.toEqual(expected);

--- a/src/get-printers/get-printers.spec.ts
+++ b/src/get-printers/get-printers.spec.ts
@@ -41,10 +41,16 @@ it("return a list of available printers", async () => {
     {
       printer: "Virtual_PDF_Printer",
       description: "Virtual PDF Printer",
+      status: "idle",
+      connection: "direct",
+      alerts: "none",
     },
     {
       printer: "Zebra",
       description: "Zebra Printer",
+      status: "idle",
+      connection: "direct",
+      alerts: "none",
     },
   ];
 

--- a/src/get-printers/get-printers.ts
+++ b/src/get-printers/get-printers.ts
@@ -1,6 +1,6 @@
 import { Printer } from "../types";
 import execAsync from "../utils/exec-async";
-import parsePrinterDescription from "../utils/parse-printer-description";
+import parsePrinterAttribute from "../utils/parse-printer-attribute";
 
 export default async function getPrinters(): Promise<Printer[]> {
   try {
@@ -14,7 +14,10 @@ export default async function getPrinters(): Promise<Printer[]> {
       .filter((line: string) => line.trim().length)
       .map((line: string) => ({
         printer: line.substr(0, line.indexOf(" ")),
-        description: parsePrinterDescription(line),
+        status: line.split(/.*is\s(\w+)\..*/gm)[1],
+        description: parsePrinterAttribute(line, "Description"),
+        alerts: parsePrinterAttribute(line, "Alerts"),
+        connection: parsePrinterAttribute(line, "Connection"),
       }));
   } catch (error) {
     throw error;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,7 @@
 export interface Printer {
   printer: string;
   description: string | null;
+  status: string | null;
+  alerts: string | null;
+  connection: string | null;
 }

--- a/src/utils/parse-printer-attribute.ts
+++ b/src/utils/parse-printer-attribute.ts
@@ -1,0 +1,10 @@
+export default function parsePrinterAttribute(
+  stdout: string,
+  attribute: string
+): string {
+  const attributeLine = stdout
+    .split("\n")
+    .slice(1)
+    .find((line: string) => line.indexOf(attribute) !== -1);
+  return attributeLine ? attributeLine.split(":")[1].trim() : "";
+}

--- a/src/utils/parse-printer-description.ts
+++ b/src/utils/parse-printer-description.ts
@@ -1,7 +1,0 @@
-export default function parsePrinterDescription(stdout: string): string {
-  const descriptionLine = stdout
-    .split("\n")
-    .slice(1)
-    .find((line: string) => line.indexOf("Description") !== -1);
-  return descriptionLine ? descriptionLine.split(":")[1].trim() : "";
-}


### PR DESCRIPTION
For some use cases it will be convenient to have more attributes about the printers, such as the status, alerts and connection. These are fetched directly from the `lpstat -lp` command so it is not necessary to make additional execs.
This PR adds the mentioned attributes to the Printer object.