### PR TITLE
fix: fix parsing for non-english systems

### DIFF
--- a/src/get-default-printer/get-default-printer.ts
+++ b/src/get-default-printer/get-default-printer.ts
@@ -19,7 +19,7 @@ function getPrinterName(output: string): string {
 }
 
 async function getPrinterData(printer: string): Promise<Printer> {
-  const { stdout } = await execAsync(`lpstat -lp ${printer}`);
+  const { stdout } = await execAsync(`SOFTWARE= LANG=C lpstat -lp ${printer}`);
   return {
     printer,
     status: stdout.split(/.*is\s(\w+)\..*/gm)[1],

--- a/src/get-printers/get-printers.ts
+++ b/src/get-printers/get-printers.ts
@@ -4,7 +4,7 @@ import parsePrinterAttribute from "../utils/parse-printer-attribute";
 
 export default async function getPrinters(): Promise<Printer[]> {
   try {
-    const { stdout } = await execAsync("lpstat -lp");
+    const { stdout } = await execAsync("SOFTWARE= LANG=C lpstat -lp");
 
     const isThereAnyPrinter = stdout.match("printer");
     if (!isThereAnyPrinter) return [];


### PR DESCRIPTION
**Main issue:**
The `getPrinters` method is returning an empty array, because the parser is searching for `printer` but on systems with different system languages will it be for example `Drucker` and don't will match for anything.
The same issue will be in the mapping of additional information.

**Solution:**
Force console output of the `lpstat -lp` command to english to make the parsing work on non-english systems.

**German systems is currently showing this result:**
```
lpstat -lp
Drucker „Brother_MFC_J4420DW“ ist inaktiv; aktiviert seit Mon Oct  2 13:55:07 2023
	Aktiviertes Formular:
	Inhaltstypen: beliebig
	Druckertypen: unbekannt
	Beschreibung: Brother MFC-J4420DW
	Hinweise: none
	Standort:
	Verbindung: direkt
	Schnittstelle: /private/etc/cups/ppd/Brother_MFC_J4420DW.ppd
	Bei Fehler: kein Hinweis
	Nach Fehler: fortsetzen
	Zugelassene Benutzer:innen:
		(alles)
	Zugelassene Formulare:
		(ohne)
	Banner erforderlich
	Zeichensätze:
		(ohne)
	Standardzeilenhöhe:
	Standardseitengröße:
	Standard-Anschlusseinstellungen:
```
**With the prefix will it be forced to english:**
```
SOFTWARE= LANG=C lpstat -lp
printer Brother_MFC_J4420DW is idle.  enabled since Mon Oct  2 13:55:07 2023
	Form mounted:
	Content types: any
	Printer types: unknown
	Description: Brother MFC-J4420DW
	Alerts: none
	Location:
	Connection: direct
	Interface: /private/etc/cups/ppd/Brother_MFC_J4420DW.ppd
	On fault: no alert
	After fault: continue
	Users allowed:
		(all)
	Forms allowed:
		(none)
	Banner required
	Charset sets:
		(none)
	Default pitch:
	Default page size:
	Default port settings:
```