### PR TITLE
fix: parsing for non-english systems, part 2

### DIFF
--- a/src/get-default-printer/get-default-printer.ts
+++ b/src/get-default-printer/get-default-printer.ts
@@ -19,7 +19,7 @@ function getPrinterName(output: string): string {
 }
 
 async function getPrinterData(printer: string): Promise<Printer> {
-  const { stdout } = await execAsync(`SOFTWARE= LANG=C lpstat -lp ${printer}`);
+  const { stdout } = await execAsync(`lpstat -lp ${printer}`);
   return {
     printer,
     status: stdout.split(/.*is\s(\w+)\..*/gm)[1],

--- a/src/get-printers/get-printers.ts
+++ b/src/get-printers/get-printers.ts
@@ -4,7 +4,7 @@ import parsePrinterAttribute from "../utils/parse-printer-attribute";
 
 export default async function getPrinters(): Promise<Printer[]> {
   try {
-    const { stdout } = await execAsync("SOFTWARE= LANG=C lpstat -lp");
+    const { stdout } = await execAsync("lpstat -lp");
 
     const isThereAnyPrinter = stdout.match("printer");
     if (!isThereAnyPrinter) return [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,6 @@ export interface Printer {
 }
 
 export interface ExecResponse {
-  stdout: string | null;
-  stderr: string | null;
+  stdout: string;
+  stderr: string;
 }

--- a/src/utils/exec-async.ts
+++ b/src/utils/exec-async.ts
@@ -6,6 +6,10 @@ import { exec } from "child_process";
 export default function execAsync(cmd: string): Promise<ExecResponse> {
     return new Promise((resolve, reject) => {
         exec(cmd, {
+            // The output from lp and lpstat is parsed assuming the language is English.
+            // LANG=C sets the language and the SOFTWARE variable is necessary
+            // on MacOS due to a detail in Apple's CUPS implementation
+            // (see https://unix.stackexchange.com/a/33836)
             env: {
                 SOFTWARE: "",
                 LANG: "C"

--- a/src/utils/exec-async.ts
+++ b/src/utils/exec-async.ts
@@ -1,7 +1,21 @@
 "use strict";
 
-const { exec } = require("child_process");
-const util = require("util");
-const execAsync = util.promisify(exec);
+import { ExecResponse } from "../types";
+import { exec } from "child_process";
 
-export default execAsync;
+export default function execAsync(cmd: string): Promise<ExecResponse> {
+    return new Promise((resolve, reject) => {
+        exec(cmd, {
+            env: {
+                SOFTWARE: "",
+                LANG: "C"
+            }
+        }, (err, stdout, stderr) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve({stdout, stderr});
+            }
+        });
+    });
+}


### PR DESCRIPTION
#24 didn't fully fix the problem with parsing on non-English systems. `isPrintComplete` requires that both `print` and its own `lpstat` outputs English, otherwise the parsing fails and it will always return false.
In fact, `execAsync` always needs to output English, so instead of adding `SOFTWARE= LANG=C` to each command in the codebase, I rewrote `execAsync` so that it always adds the environment variables there. Is this an okay change, or do you plan on using `execAsync` for other purposes where the variables aren't needed?

PS. I changed the type definition for `ExecResponse`, since `stdout` and `stderr` should never be null. The code mostly ignores the possible null anyway, and `npm build:declarations` would throw a bunch of errors before this change.
